### PR TITLE
Parsing error: user-agent label is case sensitive and collapses user-agent specific settings

### DIFF
--- a/lib/robots.rb
+++ b/lib/robots.rb
@@ -26,19 +26,19 @@ class Robots
       io.each do |line|
         next if line =~ /^\s*(#.*|$)/
         arr = line.split(":")
-        key = arr.shift
+        key = arr.shift.to_s.downcase
         value = arr.join(":").strip
         value.strip!
         case key
-        when "User-agent"
+        when "user-agent"
           agent = to_regex(value)
-        when "Allow"
+        when "allow"
           @allows[agent] ||= []
           @allows[agent] << to_regex(value)
-        when "Disallow"
+        when "disallow"
           @disallows[agent] ||= []
           @disallows[agent] << to_regex(value)
-        when "Crawl-delay"
+        when "crawl-delay"
           @delays[agent] = value.to_i
         else
           @other[key] ||= []

--- a/test/fixtures/mixcase.txt
+++ b/test/fixtures/mixcase.txt
@@ -1,0 +1,4 @@
+User-agent: *
+Disallow: /test
+User-Agent: Another
+Disallow: /

--- a/test/test_robots.rb
+++ b/test/test_robots.rb
@@ -49,8 +49,13 @@ class TestRobots < Test::Unit::TestCase
   end
   
   def test_other_values
-    sitemap = {"Sitemap" => ["http://www.eventbrite.com/sitemap_index.xml", "http://www.eventbrite.com/sitemap_index.xml"]}
+    sitemap = {"sitemap" => ["http://www.eventbrite.com/sitemap_index.xml", "http://www.eventbrite.com/sitemap_index.xml"]}
     assert_other_equals("eventbrite", sitemap)
+  end
+  
+  def test_mix_case_user_agent
+    assert_allowed("mixcase", "/")
+    assert_disallowed("mixcase", "/test")
   end
   
   def assert_other_equals(name, value)


### PR DESCRIPTION
Fix for https://github.com/fizx/robots/issues/3
@rb2k already had a fix for it but never submitted a pull request. I'm not sure why. The solution seems simple enough and I don't see any downside to it.
